### PR TITLE
Request formatting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,6 @@
                       [lein-environ "1.0.3"]
                       [lein-ring "0.9.7"]]
             :test-paths ["spec"]
-            :ring {:handler httpeek.handler/app* :auto-refresh? true}
+            :ring {:handler httpeek.handler/web-routes :auto-reload? true}
             :aliases {"migrate" ["run" "-m" "httpeek.migrations/migrate"]
                       "rollback" ["run" "-m" "httpeek.migrations/rollback"]})

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                            [environ "1.0.3"]
                            [speclj "3.3.1"]
                            [cheshire "5.6.2"]
+                           [org.clojure/data.xml "0.0.8"]
                            [ring/ring-json "0.4.0"]]
             :profiles {:test {:dependencies [[speclj "3.3.1"]]}}
             :plugins [[speclj "3.3.1"]

--- a/resources/public/css/main.css
+++ b/resources/public/css/main.css
@@ -20,3 +20,7 @@
   margin: 2rem auto 2rem auto;
   width: 80%;
 }
+
+ul.raw-request {
+ list-style-type: none;
+}

--- a/spec/httpeek/content_type_presenter_spec.clj
+++ b/spec/httpeek/content_type_presenter_spec.clj
@@ -1,0 +1,20 @@
+(ns httpeek.content-type-presenter-spec
+  (:require [speclj.core :refer :all]
+            [httpeek.content-type-presenter :refer :all]))
+
+(describe "httpeek.content-type-presenter"
+  (context "presenting the body of a supported content-type"
+    (it "correctly presents JSON"
+      (with-redefs [display-content-map {"application/json" (constantly "ok")}]
+        (should= "ok" (present-content-type "application/json" "body"))))
+
+    (it "correctly presents XML"
+      (with-redefs [display-content-map {"application/xml" (constantly "ok")}]
+        (should= "ok" (present-content-type "application/xml" "body"))))
+
+    (it "correctly presents x-www-form-url-encoded"
+      (with-redefs [display-content-map {"application/x-www-form-urlencoded" (constantly "ok")}]
+        (should= "ok" (present-content-type "application/x-www-form-urlencoded" "body"))))
+
+    (it "presents the raw if it doesn't recognize the content-type"
+        (should= "body" (present-content-type "foo/bar" "body")))))

--- a/spec/httpeek/core_spec.clj
+++ b/spec/httpeek/core_spec.clj
@@ -97,10 +97,9 @@
     (it "only deletes requests associated with the deleted bin"
       (let [bin-id (create-bin {:private false})
             first-request-id (add-request bin-id (json/encode {:position "first"}))
-            second-request-id (add-request bin-id (json/encode {:position "second"}))
-            requests (get-requests bin-id)]
+            second-request-id (add-request bin-id (json/encode {:position "second"}))]
         (delete-bin "some-other-bin-id")
-        (should-not (empty? requests))))
+        (should-not (empty? (get-requests bin-id)))))
 
   (context "deleting a non-existent bin"
     (it "returns nil"

--- a/spec/httpeek/core_spec.clj
+++ b/spec/httpeek/core_spec.clj
@@ -92,8 +92,16 @@
             bin-count (count (get-bins {:limit 50}))]
         (delete-bin bin-id)
         (should= (- bin-count 1) (count (get-bins {:limit 50})))
-        (should-be-nil (find-bin-by-id bin-id)))))
+        (should-be-nil (find-bin-by-id bin-id))))
+
+    (it "only deletes requests associated with the deleted bin"
+      (let [bin-id (create-bin {:private false})
+            first-request-id (add-request bin-id (json/encode {:position "first"}))
+            second-request-id (add-request bin-id (json/encode {:position "second"}))
+            requests (get-requests bin-id)]
+        (delete-bin "some-other-bin-id")
+        (should-not (empty? requests))))
 
   (context "deleting a non-existent bin"
     (it "returns nil"
-        (should-be-nil (delete-bin -1)))))
+        (should-be-nil (delete-bin -1))))))

--- a/spec/httpeek/db_spec.clj
+++ b/spec/httpeek/db_spec.clj
@@ -64,8 +64,7 @@
         (should= first-request-id (:id (first requests)))
         (should= {:position "first"} (:full_request (first requests)))
         (should= second-request-id (:id (second requests)))
-        (should= {:position "second"} (:full_request (second requests)))
-        )))
+        (should= {:position "second"} (:full_request (second requests))))))
 
   (context "deleting a bin"
     (it "removes a record from the bin table"
@@ -79,4 +78,12 @@
       (let [bin-id (create-bin false)
             fake-bin-id nil]
         (should= 1 (delete-bin bin-id))
-        (should= 0 (delete-bin fake-bin-id))))))
+        (should= 0 (delete-bin fake-bin-id))))
+
+    (it "deletes all requests associated with a deleted bin"
+      (let [bin-id (create-bin false)
+            first-request-id (add-request bin-id (json/encode {:position "first"}))
+            second-request-id (add-request bin-id (json/encode {:position "second"}))]
+        (delete-bin bin-id)
+        (should-be-nil (find-request-by-id first-request-id))
+        (should-be-nil (find-request-by-id second-request-id))))))

--- a/spec/httpeek/handler_spec.clj
+++ b/spec/httpeek/handler_spec.clj
@@ -141,16 +141,14 @@
         (let  [bin-id (core/create-bin {:private true})
                valid-request (web-routes (mock/header (mock/request :get (format "/bin/%s" bin-id)) :foo "bar"))
                response (web-routes (assoc (mock/request :get (format "/bin/%s/inspect" bin-id)) :session {:private-bins [bin-id]}))]
-          (should= 200 (:status response))
-          (should-contain "foo: bar" (:body response)))))
+          (should= 200 (:status response)))))
 
     (context "getting an existing public bin with request added"
       (it "returns a 200 status"
         (let  [bin-id (core/create-bin {:private false})
                valid-request (web-routes (mock/header (mock/request :get (format "/bin/%s" bin-id)) :foo "bar"))
                response (web-routes (mock/request :get (format "/bin/%s/inspect" bin-id)))]
-          (should= 200 (:status response))
-          (should-contain "foo: bar" (:body response)))))
+          (should= 200 (:status response)))))
 
     (context "getting a non-existent bin"
       (it "returns a 404 status"

--- a/spec/httpeek/handler_spec.clj
+++ b/spec/httpeek/handler_spec.clj
@@ -3,11 +3,31 @@
             [httpeek.handler :refer :all]
             [ring.mock.request :as mock]
             [httpeek.spec-helper :as helper]
+            [ring.util.io :as r-io]
             [cheshire.core :as json]
             [httpeek.core :as core]))
 
 (describe "httpeek.handler"
   (after (helper/reset-db))
+
+  (context "malformed XML request"
+    (it "responds with the a default malformed xml response"
+      (let [handler (wrap-xml-params identity)
+            request {:headers {"content-type" "application/xml"}
+                     :body (r-io/string-input-stream "not-xml")}
+            response (handler request)]
+        (should= 400 (:status response))
+        (should= "Malformed XML in request body." (:body response)))))
+
+  (context "proper XML request"
+    (it "appends an xml-params key and value to the response map"
+      (let [handler (wrap-xml-params identity)
+            request (-> (mock/request :get "/bin/some-bin")
+                      (assoc :body (r-io/string-input-stream "<root><child>aaa</child><child/></root>"))
+                      (assoc-in [:headers "content-type"] "text/xml"))
+            response (handler request)]
+        (should= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\n  <child>aaa</child>\n  <child/>\n</root>\n"
+                 (:xml-params response)))))
 
   (context "/api"
     (context "GET /"

--- a/spec/httpeek/handler_spec.clj
+++ b/spec/httpeek/handler_spec.clj
@@ -168,7 +168,7 @@
    (context "DELETE request to existing bin"
      (it "redirects to the index page"
       (let [bin-id (core/create-bin {:private false})
-            response (app* (mock/request :delete (str "/bin/" bin-id "/delete")))]
+            response (app* (mock/request :get (str "/bin/" bin-id "/delete")))]
         (should= 302 (:status response)))))
 
    (context "DELETE request to non-existent bin"

--- a/spec/httpeek/handler_spec.clj
+++ b/spec/httpeek/handler_spec.clj
@@ -120,14 +120,14 @@
     (context "getting an existing private bin with request added"
       (it "returns a 200 status"
         (let  [bin-id (core/create-bin {:private true})
-               valid-request (web-routes (mock/header (mock/request :get (format "/bin/%s" bin-id)) :foo "bar"))
+               valid-request (web-routes (assoc (mock/request :get (format "/bin/%s" bin-id)) :protocol "HTTP/1.1"))
                response (web-routes (assoc (mock/request :get (format "/bin/%s/inspect" bin-id)) :session {:private-bins [bin-id]}))]
           (should= 200 (:status response)))))
 
     (context "getting an existing public bin with request added"
       (it "returns a 200 status"
         (let  [bin-id (core/create-bin {:private false})
-               valid-request (web-routes (mock/header (mock/request :get (format "/bin/%s" bin-id)) :foo "bar"))
+               valid-request (web-routes (assoc (mock/request :get (format "/bin/%s" bin-id)) :protocol "HTTP/1.1"))
                response (web-routes (mock/request :get (format "/bin/%s/inspect" bin-id)))]
           (should= 200 (:status response)))))
 

--- a/spec/httpeek/handler_spec.clj
+++ b/spec/httpeek/handler_spec.clj
@@ -10,25 +10,6 @@
 (describe "httpeek.handler"
   (after (helper/reset-db))
 
-  (context "malformed XML request"
-    (it "responds with the a default malformed xml response"
-      (let [handler (wrap-xml-params identity)
-            request {:headers {"content-type" "application/xml"}
-                     :body (r-io/string-input-stream "not-xml")}
-            response (handler request)]
-        (should= 400 (:status response))
-        (should= "Malformed XML in request body." (:body response)))))
-
-  (context "proper XML request"
-    (it "appends an xml-params key and value to the response map"
-      (let [handler (wrap-xml-params identity)
-            request (-> (mock/request :get "/bin/some-bin")
-                      (assoc :body (r-io/string-input-stream "<root><child>aaa</child><child/></root>"))
-                      (assoc-in [:headers "content-type"] "text/xml"))
-            response (handler request)]
-        (should= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\n  <child>aaa</child>\n  <child/>\n</root>\n"
-                 (:xml-params response)))))
-
   (context "/api"
     (context "GET /"
       (it "returns a json response of all existing bins"

--- a/spec/httpeek/handler_spec.clj
+++ b/spec/httpeek/handler_spec.clj
@@ -168,10 +168,10 @@
    (context "DELETE request to existing bin"
      (it "redirects to the index page"
       (let [bin-id (core/create-bin {:private false})
-            response (app* (mock/request :get (str "/bin/" bin-id "/delete")))]
+            response (app* (mock/request :post (str "/bin/" bin-id "/delete")))]
         (should= 302 (:status response)))))
 
    (context "DELETE request to non-existent bin"
      (it "returns a 404 status"
-      (let [response (app* (mock/request :delete (str "/bin/" -1 "/delete")))]
+      (let [response (app* (mock/request :post (str "/bin/" -1 "/delete")))]
         (should= 404 (:status response)))))))

--- a/spec/httpeek/json_formatter_spec.clj
+++ b/spec/httpeek/json_formatter_spec.clj
@@ -1,0 +1,15 @@
+(ns httpeek.json-formatter-spec
+  (:require [speclj.core :refer :all]
+            [httpeek.json-formatter :refer :all]))
+
+(describe "httpeek.json-formatter"
+  (context "formatting a json string"
+    (it "correctly formats a proper json string"
+      (let  [formatted-json (format-json "{\"foo\":\"bar\"}")]
+        (should= "{\n  \"foo\" : \"bar\"\n}"
+                 formatted-json)))
+
+    (it "returns a error message if the json string is malformed"
+      (let  [formatted-json (format-json "not-a-json-string")]
+        (should= "Malformed JSON in the request body"
+                 formatted-json)))))

--- a/spec/httpeek/xml_formatter_spec.clj
+++ b/spec/httpeek/xml_formatter_spec.clj
@@ -1,0 +1,16 @@
+(ns httpeek.xml-formatter-spec
+  (:require [httpeek.xml-formatter :refer :all]
+            [speclj.core :refer :all]))
+
+(describe "httpeek.xml-formatter"
+  (context "formatting a proper xml string"
+    (it "formats the xml string"
+      (let [formatted-xml (format-xml "<root><child>aaa</child><child/></root>")]
+        (should= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\n  <child>aaa</child>\n  <child/>\n</root>\n"
+                 formatted-xml)))
+
+    (it "it returns an error message if the xml is malformed"
+      (let [formatted-xml (format-xml "not-an-xml-string")]
+        (should= "Malformed XML in the request body"
+                 formatted-xml)))))
+

--- a/src/httpeek/content_type_presenter.clj
+++ b/src/httpeek/content_type_presenter.clj
@@ -1,0 +1,14 @@
+(ns httpeek.content-type-presenter
+  (:require [httpeek.json-formatter :as json]
+            [httpeek.xml-formatter :as xml]))
+
+(def display-content-map
+  {"application/json" json/format-json
+   "text/xml" xml/format-xml
+   "application/xml" xml/format-xml
+   "application/x-www-form-urlencoded" identity})
+
+(defn present-content-type [content-type body]
+  (if-let [formatting-function (get display-content-map content-type)]
+    (formatting-function body)
+    body))

--- a/src/httpeek/db.clj
+++ b/src/httpeek/db.clj
@@ -48,5 +48,6 @@
   (j/query db (str "SELECT * FROM requests WHERE bin_id='"bin-id "';")))
 
 (defn delete-bin [bin-id]
+  (j/delete! db :requests ["bin_id = ?" bin-id])
   (-> (j/delete! db :bins ["id = ?" bin-id])
     first))

--- a/src/httpeek/db.clj
+++ b/src/httpeek/db.clj
@@ -48,6 +48,6 @@
   (j/query db (str "SELECT * FROM requests WHERE bin_id='"bin-id "';")))
 
 (defn delete-bin [bin-id]
-  (j/delete! db :requests ["bin_id = ?" bin-id])
-  (-> (j/delete! db :bins ["id = ?" bin-id])
-    first))
+  (first (j/with-db-transaction [db db]
+                         (j/delete! db :requests ["bin_id = ?" bin-id])
+                         (j/delete! db :bins ["id = ?" bin-id]))))

--- a/src/httpeek/handler.clj
+++ b/src/httpeek/handler.clj
@@ -30,7 +30,7 @@
 
 (defn- parse-request-to-bin [request]
   (let [id (str->uuid (get-in request [:params :id]))
-        body (json/encode request {:pretty true})
+        body (json/encode (dissoc request :body) {:pretty true})
         requested-bin (core/find-bin-by-id id)]
     {:requested-bin requested-bin
      :body body}))

--- a/src/httpeek/handler.clj
+++ b/src/httpeek/handler.clj
@@ -110,7 +110,7 @@
   (POST "/bins" {form-params :form-params} (handle-web-create-bin form-params))
   (GET "/bin/:id/inspect" [id :as {session :session headers :headers}] (handle-web-inspect-bin (str->uuid id) session headers))
   (ANY "/bin/:id" req (handle-web-request-to-bin req))
-  (GET "/bin/:id/delete" [id] (handle-web-delete-bin id))
+  (POST "/bin/:id/delete" [id] (handle-web-delete-bin id))
   (route/resources "/")
   (route/not-found (views/not-found-page)))
 

--- a/src/httpeek/handler.clj
+++ b/src/httpeek/handler.clj
@@ -1,18 +1,13 @@
 (ns httpeek.handler
   (:use compojure.core)
   (:require [ring.util.response :as response]
-            [ring.middleware.params :as middleware]
             [ring.middleware.session :as session]
             [ring.middleware.json :as ring-json]
             [clojure.data.xml :as xml]
             [compojure.route :as route]
             [httpeek.core :as core]
             [cheshire.core :as json]
-            [httpeek.views :as views])
-  (:import [java.io StringReader StringWriter]
-           [javax.xml.transform TransformerFactory OutputKeys]
-           [org.xml.sax SAXParseException]
-           [javax.xml.transform.stream StreamSource StreamResult]))
+            [httpeek.views :as views]))
 
 (defn- str->uuid [uuid-string]
   (core/with-error-handling nil
@@ -28,9 +23,15 @@
         (views/inspect-bin-page id (core/get-requests id)))
       (response/not-found (views/not-found-page)))))
 
+(defn- slurp-body [request]
+  (if (:body request)
+    (update request :body slurp)
+    request))
+
 (defn- parse-request-to-bin [request]
-  (let [id (str->uuid (get-in request [:params :id]))
-        body (json/encode (dissoc request :body) {:pretty true})
+  (let [request (slurp-body request)
+        id (str->uuid (get-in request [:params :id]))
+        body (json/encode request {:pretty true})
         requested-bin (core/find-bin-by-id id)]
     {:requested-bin requested-bin
      :body body}))
@@ -111,52 +112,8 @@
   (route/resources "/")
   (route/not-found (views/not-found-page)))
 
-(defn ppxml [xml-str]
-  (let [in  (StreamSource. (StringReader. xml-str))
-        out (StreamResult. (StringWriter.))
-        transformer (.newTransformer
-                     (TransformerFactory/newInstance))]
-    (doseq [[prop val] {OutputKeys/INDENT "yes"
-                        OutputKeys/METHOD "xml"
-                        "{http://xml.apache.org/xslt}indent-amount" "2"}]
-      (.setOutputProperty transformer prop val))
-    (.transform transformer in out)
-    (str (.getWriter out))))
-
-(defn- xml-request? [request]
-  (if-let [content-type (get-in request [:headers "content-type"])]
-    (not (empty? (re-find #"(application/xml)|(text/xml)" content-type)))))
-
-(def default-malformed-xml-response
-  {:status 400
-   :headers {"Content-Type" "text/plain"}
-   :body "Malformed XML in request body."})
-
-(defn- read-xml [request]
-  (if (xml-request? request)
-    (if-let [body (slurp (:body request))]
-      [true (core/with-error-handling nil
-                                (ppxml body))]
-      [false nil])))
-
-(defn- assoc-xml-params [request formatted-xml]
-  (-> request
-    (assoc :xml-params formatted-xml)))
-
-(defn wrap-xml-params [handler]
-  (fn [request]
-    (if-let [[valid? formatted-xml] (read-xml request)]
-      (if (and valid? (not (nil? formatted-xml)))
-        (handler (assoc-xml-params request formatted-xml))
-        default-malformed-xml-response)
-      (handler request))))
-
 (def app*
   (routes (-> api-routes
-            (wrap-routes ring-json/wrap-json-response)
             (ring-json/wrap-json-response))
           (-> web-routes
-            (middleware/wrap-params)
-            (ring-json/wrap-json-params)
-            (session/wrap-session)
-            (wrap-xml-params))))
+            (session/wrap-session))))

--- a/src/httpeek/json_formatter.clj
+++ b/src/httpeek/json_formatter.clj
@@ -1,0 +1,14 @@
+(ns httpeek.json-formatter
+  (:require [cheshire.core :as json]
+            [httpeek.core :as core]))
+
+(defn- beautify-json [json-string]
+  (-> json-string
+    json/decode
+    (json/encode {:pretty true})))
+
+(defn format-json [json-string]
+  (core/with-error-handling "Malformed JSON in the request body"
+                            (beautify-json json-string)))
+
+

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -161,7 +161,7 @@
    (navbar)
    [:main.mdl-layout__content
     [:h4.bin-title (h/h (format "URL: %s/bin/%s" host id))]
-    [:form.bin-title {:action (h/h (format "/bin/%s/delete" id)) :method "get"}
+    [:form.bin-title {:action (h/h (format "/bin/%s/delete" id)) :method "POST"}
      [:button.mdl-button.mdl-js-button.mdl.button--fab.mdl-button--colored {:type "submit"} (h/h "Delete Bin")
       [:i.material-icons (h/h "delete")]]]
    (if (= (count requests) 0)

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -54,7 +54,8 @@
 
 (defn list-headers [headers]
   [:ul.mdl-list
-   (map (fn [[k v]] [:li.mdl-list__item (str (name k) ": " v)]) headers)])
+   (map (fn [[k v]] [:li.mdl-list__item
+                     [:b (name k) ] (str ": " v)]) headers)])
 
 (defn request-card [request]
   (let [{:keys [created_at]} request

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -1,13 +1,8 @@
 (ns httpeek.views
   (require [hiccup.page :as page]
            [httpeek.core :as core]
-           [hiccup.core :as h]
-           [httpeek.xml-formatter :as xml]
-           [httpeek.json-formatter :as json])
-  (:import [java.io StringReader StringWriter]
-           [javax.xml.transform TransformerFactory OutputKeys]
-           [org.xml.sax SAXParseException]
-           [javax.xml.transform.stream StreamSource StreamResult]))
+           [httpeek.content-type-presenter :as presenter]
+           [hiccup.core :as h]))
 
 (defn navbar []
   [:div.mdl-layout.mdl-layout--fixed-header
@@ -64,15 +59,6 @@
    (map (fn [[k v]] [:li.mdl-list__item
                      [:p [:b (name k) ] (str ": " v)]]) headers)])
 
-(def display-content-map
-  {"application/json" json/format-json
-   "text/xml" xml/format-xml
-   "application/xml" xml/format-xml
-   "application/x-www-form-urlencoded" identity})
-
-(defn- display-content [content-type body]
-  ((get display-content-map content-type) body))
-
 (defn raw-headers [headers]
    (map (fn [[k v]] [:li
                      (str (name k) ": " v)]) headers))
@@ -109,7 +95,7 @@
          [:div.mdl-cell.mdl-cell--6-col (list-headers headers)]
          (if-let [content-type (:content-type headers)]
            [:div.mdl-cell.mdl-cell--6-col
-            [:pre (h/h (display-content content-type body))]])]]]
+            [:pre (h/h (presenter/present-content-type content-type body))]])]]]
       [:div#raw-request.mdl-tabs__panel
         [:div.mdl-card__actions.mdl-card--border
         [:div.mdl-grid

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -97,9 +97,9 @@
                      (str (name k) ": " v)]) headers))
 
 (defn display-raw-request [{:keys [request-method protocol uri headers body] :as full-request}]
-  [:ul
+  [:ul.raw-request
    [:li (str (clojure.string/upper-case request-method) " "
-             (clojure.string/upper-case uri) " "
+             uri " "
              (clojure.string/upper-case protocol) "\r\n")]
    (raw-headers headers)
    (if (not (empty? body))
@@ -160,8 +160,10 @@
   [:body
    (navbar)
    [:main.mdl-layout__content
-    [:h4.bin-title (h/h "Bin-URL")]
-    [:h4.bin-title (h/h (str host "/bin/" id))]
+    [:h4.bin-title (h/h (format "URL: %s/bin/%s" host id))]
+    [:form.bin-title {:action (h/h (format "/bin/%s/delete" id)) :method "get"}
+     [:button.mdl-button.mdl-js-button.mdl.button--fab.mdl-button--colored {:type "submit"} (h/h "Delete Bin")
+      [:i.material-icons (h/h "delete")]]]
    (if (= (count requests) 0)
      (code-example-card host id)
      (for [request requests]

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -2,7 +2,8 @@
   (require [hiccup.page :as page]
            [httpeek.core :as core]
            [hiccup.core :as h]
-           [httpeek.xml-formatter :as xml])
+           [httpeek.xml-formatter :as xml]
+           [httpeek.json-formatter :as json])
   (:import [java.io StringReader StringWriter]
            [javax.xml.transform TransformerFactory OutputKeys]
            [org.xml.sax SAXParseException]
@@ -63,13 +64,8 @@
    (map (fn [[k v]] [:li.mdl-list__item
                      [:p [:b (name k) ] (str ": " v)]]) headers)])
 
-(defn- format-json [body]
-  (-> body
-    cheshire.core/decode
-    (cheshire.core/encode {:pretty true})))
-
 (def display-content-map
-  {"application/json" format-json
+  {"application/json" json/format-json
    "text/xml" xml/format-xml
    "application/xml" xml/format-xml
    "application/x-www-form-urlencoded" identity})

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -60,7 +60,7 @@
 (defn list-headers [headers]
   [:ul.mdl-list
    (map (fn [[k v]] [:li.mdl-list__item
-                     [:b (name k) ] (str ": " v)]) headers)])
+                     [:p [:b (name k) ] (str ": " v)]]) headers)])
 
 (defn ppxml [xml-str]
   (let [in  (StreamSource. (StringReader. xml-str))
@@ -92,6 +92,19 @@
 (defn- display-content [content-type body]
   ((get display-content-map content-type) body))
 
+(defn raw-headers [headers]
+   (map (fn [[k v]] [:li
+                     (str (name k) ": " v)]) headers))
+
+(defn display-raw-request [{:keys [request-method protocol uri headers body] :as full-request}]
+  [:ul
+   [:li (str (clojure.string/upper-case request-method) " "
+             (clojure.string/upper-case uri) " "
+             (clojure.string/upper-case protocol) "\r\n")]
+   (raw-headers headers)
+   (if (not (empty? body))
+   [:li body])])
+
 (defn request-card [request]
   (let [{:keys [created_at full_request]} request
         {{:keys [headers body
@@ -122,7 +135,7 @@
          [:div.mdl-cell.mdl-cell--8-col
           [:h4 (h/h (str "Raw Request"))]]]
         [:div.mdl-grid
-         [:div.mdl-cell.mdl-cell--8-col (str full_request)]]]]]]))
+         [:div.mdl-cell.mdl-cell--8-col (display-raw-request full_request)]]]]]]))
 
 (defn index-html []
   [:body

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -149,22 +149,23 @@
     [:div
      [:h1 (h/h "Sorry! The Page You were looking for cannot be found")]]))
 
-(defn code-example-card []
+(defn code-example-card [host id]
   [:div.index-card.mdl-card.mdl-shadow--2dp
    [:div.mdl-card__title
     [:h2.mdl-card__title-text (h/h "make a request to get started")]]
    [:div.mdl-card__actions.mdl-card--border
-    [:code (h/h "curl -X POST -d foo=bar 'this bin url'")]]])
+    [:code (h/h (format "curl -X POST -d foo=bar %s/bin/%s" host id))]]])
 
-(defn inspect-html [id requests]
+(defn inspect-html [id host requests]
   [:body
    (navbar)
    [:main.mdl-layout__content
-    [:h3.bin-title (h/h (str "Bin-Url: /bin/" id))]]
+    [:h4.bin-title (h/h "Bin-URL")]
+    [:h4.bin-title (h/h (str host "/bin/" id))]
    (if (= (count requests) 0)
-     (code-example-card)
+     (code-example-card host id)
      (for [request requests]
-       (request-card request)))])
+       (request-card request)))]])
 
 (defn wrap-layout [component]
   (page/html5
@@ -175,8 +176,8 @@
 (defn index-page []
   (wrap-layout (index-html )))
 
-(defn inspect-bin-page [bin-id requests]
-  (wrap-layout (inspect-html bin-id requests)))
+(defn inspect-bin-page [bin-id host requests]
+  (wrap-layout (inspect-html bin-id host requests)))
 
 (defn not-found-page []
   (wrap-layout (not-found-html)))

--- a/src/httpeek/xml_formatter.clj
+++ b/src/httpeek/xml_formatter.clj
@@ -1,0 +1,27 @@
+(ns httpeek.xml-formatter
+  (:require [httpeek.core :as core])
+  (:import [java.io StringReader StringWriter]
+           [javax.xml.transform TransformerFactory OutputKeys]
+           [org.xml.sax SAXParseException]
+           [javax.xml.transform.stream StreamSource StreamResult]))
+
+(def xml-transformer
+  (delay (let [transformer (.newTransformer (TransformerFactory/newInstance))]
+    (doseq [[prop val] {OutputKeys/INDENT "yes"
+                        OutputKeys/METHOD "xml"
+                        "{http://xml.apache.org/xslt}indent-amount" "2"}]
+      (.setOutputProperty transformer prop val))
+    transformer)))
+
+(defn- ppxml [xml-str]
+  (let [in  (StreamSource. (StringReader. xml-str))
+        out (StreamResult. (StringWriter.))
+        transformer @xml-transformer]
+    (.transform transformer in out)
+    (str (.getWriter out))))
+
+(defn format-xml [xml-string]
+  (core/with-error-handling "Malformed XML in the request body"
+                            (ppxml xml-string)))
+
+


### PR DESCRIPTION
This PR addresses the following stories:

As a user,
I can see the Headers on the left side of the pane instead of the right

As a user,
I can toggle to see a raw request body, and a formatted request body for the following types:
url-form-encoded, xml, json

As a user,
I can delete a bin by clicking the delete bin button on a bin's inspect page

*NOTE
- Path to delete is a GET not a DELETE, spent some time trying to make it a delete but could not find a clean way of doing it.
