### PR TITLE
Ephemeral bins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ pom.xml
 .lein-plugins
 .lein-repl-history
 .lein-env
+.nrepl-port
 /dev-resources

--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,7 @@
                       [lein-environ "1.0.3"]
                       [lein-ring "0.9.7"]]
             :test-paths ["spec"]
+            :jvm-opts ["-Duser.timezone=UTC"]
             :ring {:handler httpeek.handler/app* :auto-reload? true}
             :aliases {"migrate" ["run" "-m" "httpeek.migrations/migrate"]
                       "rollback" ["run" "-m" "httpeek.migrations/rollback"]})

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                            [migratus "0.8.25"]
                            [environ "1.0.3"]
                            [speclj "3.3.1"]
+                           [clojurewerkz/quartzite "2.0.0"]
                            [cheshire "5.6.2"]
                            [com.novemberain/validateur "2.5.0"]
                            [org.clojure/data.xml "0.0.8"]

--- a/resources/migrations/20160616164700-create-bins-table.up.sql
+++ b/resources/migrations/20160616164700-create-bins-table.up.sql
@@ -2,5 +2,6 @@ CREATE TABLE bins(
   id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   private             boolean NOT NULL,
   response            jsonb NOT NULL,
+  expiration          timestamp NOT NULL,
   created_at          timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/spec/httpeek/core_spec.clj
+++ b/spec/httpeek/core_spec.clj
@@ -7,6 +7,14 @@
 (describe "httpeek.core"
   (after (helper/reset-db))
 
+  (context "When validating user-inputted expiration time"
+    (context "And the expiration time is less than 1 or greater than 24 hours"
+      (it "returns a map of errors"
+       (let [less-than-time-range-error (validate-expiration {:time-to-expiration 0})
+             greater-than-time-range-error (validate-expiration {:time-to-expiration 50})]
+         (should= #{"expiration time must be an integer between 1 and 24"} less-than-time-range-error)
+         (should= #{"expiration time must be an integer between 1 and 24"} greater-than-time-range-error)))))
+
   (context "When validating a user-inputted response"
     (context "And the response-map is well-formed"
       (it "returns nil"

--- a/spec/httpeek/db_spec.clj
+++ b/spec/httpeek/db_spec.clj
@@ -2,6 +2,7 @@
   (require [speclj.core :refer :all]
            [httpeek.db :refer :all]
            [httpeek.spec-helper :as helper]
+           [clj-time.core :as t]
            [cheshire.core :as json]))
 
 (describe "httpeek.db"
@@ -10,28 +11,42 @@
   (context "When retrieving bins"
     (it "gets a specified number of bins"
       (let [bins (repeatedly 50 #(create-bin {:private false
-                                              :response helper/bin-response}))]
-        (should= (count bins) (count (get-bins 50))))))
+                                              :response helper/bin-response
+                                              :expiration (t/from-now (t/hours 24))}))]
+        (should= (count bins) (count (get-bins 50)))))
+
+    (it "only retrieves unexpired bins"
+      (let [bin (create-bin {:private false
+                             :response helper/bin-response
+                             :expiration (t/from-now (t/hours 24))})
+            expired-bin (create-bin {:private false
+                                     :response helper/bin-response
+                                     :expiration (t/ago (t/hours 24))})]
+        (should-contain bin (map #(get % :id) (get-bins 10)))
+        (should-not-contain expired-bin (map #(get % :id) (get-bins 10))))))
 
   (context "When creating a bin"
     (it "adds a new public bin record to the bin table"
       (let [bin-count (count (get-bins 50))
             bin-id(create-bin {:private false
-                               :response helper/bin-response})]
+                               :response helper/bin-response
+                               :expiration (t/from-now (t/hours 24))})]
         (should= (+ 1 bin-count)
                  (count (get-bins 50)))))
 
     (it "adds a new private bin record to the bin table"
       (let [bin-count (count (get-bins 50))
             bin-id(create-bin {:private true
-                               :response helper/bin-response})]
+                               :response helper/bin-response
+                               :expiration (t/from-now (t/hours 24))})]
         (should= (+ 1 bin-count)
                  (count (get-bins 50))))))
 
   (context "When finding a bin"
     (it "finds a public bin with a custom response"
       (let [bin-id (create-bin {:private false
-                                :response  helper/bin-response})]
+                                :response  helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})]
         (should= bin-id (:id (find-bin-by-id bin-id)))
         (should= 500 (:status (:response (find-bin-by-id bin-id))))
         (should= {:foo "bar"} (:headers (:response (find-bin-by-id bin-id))))
@@ -39,7 +54,8 @@
 
     (it "finds a private bin"
       (let [bin-id (create-bin {:private true
-                                :response helper/bin-response})]
+                                :response helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})]
         (should= bin-id (:id (find-bin-by-id bin-id)))
         (should= true (:private (find-bin-by-id bin-id))))))
 
@@ -47,7 +63,8 @@
   (context "When a request is created successfully"
     (it "adds a request to an existing bin"
       (let [bin-id (create-bin {:private false
-                                :response helper/bin-response})
+                                :response helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})
             full-request (json/encode {:foo "bar"})
             request-count (count (all-requests))]
         (let [request-id (add-request bin-id full-request)]
@@ -56,7 +73,8 @@
 
     (it "has the correct details"
       (let [bin-id (create-bin {:private false
-                                :response helper/bin-response})
+                                :response helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})
             full-request (json/encode {:foo "bar"})
             request-id (add-request bin-id (json/encode full-request))
             request (find-request-by-id request-id)]
@@ -65,7 +83,9 @@
         (should= bin-id (:bin_id request))))
 
     (it "should be associated with a current bin-id"
-      (let [bin-id (create-bin {:private false :response helper/bin-response})
+      (let [bin-id (create-bin {:private false
+                                :response helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})
             first-request-id (add-request bin-id (json/encode {:position "first"}))
             second-request-id (add-request bin-id (json/encode {:position "second"}))
             requests (find-requests-by-bin-id bin-id)]
@@ -77,20 +97,26 @@
 
   (context "When deleting a bin"
     (it "removes a record from the bin table"
-      (let [bin-id (create-bin {:private false :response helper/bin-response})
+      (let [bin-id (create-bin {:private false
+                                :response helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})
             bin-count (count (get-bins 50))]
         (delete-bin bin-id)
         (should= (- 1 bin-count) (count (get-bins 50)))
         (should-be-nil (find-bin-by-id bin-id))))
 
     (it "returns the count of bins deleted"
-      (let [bin-id (create-bin {:private false :response helper/bin-response})
+      (let [bin-id (create-bin {:private false
+                                :response helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})
             fake-bin-id nil]
         (should= 1 (delete-bin bin-id))
         (should= 0 (delete-bin fake-bin-id))))
 
     (it "deletes all requests associated with a deleted bin"
-      (let [bin-id (create-bin {:private false :response helper/bin-response})
+      (let [bin-id (create-bin {:private false
+                                :response helper/bin-response
+                                :expiration (t/from-now (t/hours 24))})
             first-request-id (add-request bin-id (json/encode {:position "first"}))
             second-request-id (add-request bin-id (json/encode {:position "second"}))]
         (delete-bin bin-id)

--- a/spec/httpeek/jobs_spec.clj
+++ b/spec/httpeek/jobs_spec.clj
@@ -1,0 +1,17 @@
+(ns httpeek.jobs-spec
+  (:require [speclj.core :refer :all]
+            [clojurewerkz.quartzite.jobs :as j]
+            [clojurewerkz.quartzite.scheduler :as qs]
+            [httpeek.jobs :refer :all])
+  (:import [httpeek.jobs DeleteExpired]))
+
+(describe "httpeek.jobs"
+
+  (context "When scheduling a job"
+    (it "actually schedules the job"
+      (let [trigger (configure-trigger {:trigger-key "trigger.ms"
+                                        :schedule sched-once-every-200-ms})
+            job (build-job {:job-type DeleteExpired
+                            :job-key "mock-job"})
+            scheduler (schedule job trigger)]
+        (should (qs/scheduled? scheduler (j/key "mock-job")))))))

--- a/src/httpeek/core.clj
+++ b/src/httpeek/core.clj
@@ -1,6 +1,7 @@
 (ns httpeek.core
   (:require [httpeek.db :as db]
             [validateur.validation :as v]
+            [clj-time.core :as t]
             [cheshire.core :as json]))
 
 (defmacro with-error-handling [default form]
@@ -8,6 +9,17 @@
      ~form
      (catch Exception e#
        ~default)))
+
+(defn validate-expiration [time-to-expiration]
+  (let [validator (v/validation-set
+                    (v/numericality-of :time-to-expiration
+                                       :only-integer true
+                                       :gte 1
+                                       :lte 24
+                                       :message-fn (fn [type _ _ & args]
+                                                     (if (or (= :gte type) (= :lte type) (= :only-integer type))
+                                                       "expiration time must be an integer between 1 and 24"))))]
+    (v/errors :time-to-expiration (validator time-to-expiration))))
 
 (defn- format-errors [errors-map]
   (let [status-errors (v/errors :status errors-map)
@@ -27,12 +39,14 @@
                 :headers {}
                 :body "ok"}))
 
-(defn create-bin [{:keys [private response],
+(defn create-bin [{:keys [private response time-to-expiration],
                    :or {private false
-                        response default-response}}]
+                        response default-response
+                        time-to-expiration 24}}]
   (with-error-handling nil
     (db/create-bin {:private private
-                    :response response})))
+                    :response response
+                    :expiration (t/from-now (t/hours time-to-expiration))})))
 
 (defn find-bin-by-id [id]
   (with-error-handling nil

--- a/src/httpeek/core.clj
+++ b/src/httpeek/core.clj
@@ -17,7 +17,7 @@
                                        :gte 1
                                        :lte 24
                                        :message-fn (fn [type _ _ & args]
-                                                     (if (or (= :gte type) (= :lte type) (= :only-integer type))
+                                                     (if (some #{type} [:gte :lte :only-integer])
                                                        "expiration time must be an integer between 1 and 24"))))]
     (v/errors :time-to-expiration (validator time-to-expiration))))
 

--- a/src/httpeek/db.clj
+++ b/src/httpeek/db.clj
@@ -19,13 +19,13 @@
         "jsonb" (json/decode value true)
         :else value))))
 
-(defn create-bin [{:keys [private response] :as bin-options}]
-  (-> (j/query db (str "INSERT INTO bins VALUES(DEFAULT, '" private "', '" response "', DEFAULT) returning id;"))
+(defn create-bin [{:keys [private response expiration] :as bin-options}]
+  (-> (j/query db (str "INSERT INTO bins VALUES(DEFAULT, '" private "', '" response "', '" expiration "', DEFAULT) returning id;"))
     first
     :id))
 
 (defn get-bins [limit]
-  (j/query db (str "SELECT * FROM bins LIMIT " limit ";")))
+  (j/query db (str "SELECT * FROM bins WHERE expiration > now() LIMIT " limit ";")))
 
 (defn all-requests []
   (j/query db

--- a/src/httpeek/db.clj
+++ b/src/httpeek/db.clj
@@ -19,6 +19,9 @@
         "jsonb" (json/decode value true)
         :else value))))
 
+(defn delete-expired-bins []
+  (j/delete! db :bins ["expiration < now()"]))
+
 (defn create-bin [{:keys [private response expiration] :as bin-options}]
   (-> (j/query db (str "INSERT INTO bins VALUES(DEFAULT, '" private "', '" response "', '" expiration "') returning id;"))
     first

--- a/src/httpeek/db.clj
+++ b/src/httpeek/db.clj
@@ -51,4 +51,3 @@
   (first (j/with-db-transaction [db db]
                          (j/delete! db :requests ["bin_id = ?" bin-id])
                          (j/delete! db :bins ["id = ?" bin-id]))))
-

--- a/src/httpeek/db.clj
+++ b/src/httpeek/db.clj
@@ -20,7 +20,7 @@
         :else value))))
 
 (defn create-bin [{:keys [private response expiration] :as bin-options}]
-  (-> (j/query db (str "INSERT INTO bins VALUES(DEFAULT, '" private "', '" response "', '" expiration "', DEFAULT) returning id;"))
+  (-> (j/query db (str "INSERT INTO bins VALUES(DEFAULT, '" private "', '" response "', '" expiration "') returning id;"))
     first
     :id))
 
@@ -51,3 +51,4 @@
   (first (j/with-db-transaction [db db]
                          (j/delete! db :requests ["bin_id = ?" bin-id])
                          (j/delete! db :bins ["id = ?" bin-id]))))
+

--- a/src/httpeek/jobs.clj
+++ b/src/httpeek/jobs.clj
@@ -1,0 +1,38 @@
+(ns httpeek.jobs
+  (:require [clojurewerkz.quartzite.scheduler :as qs]
+            [clojurewerkz.quartzite.jobs :as j]
+            [httpeek.db :as db]
+            [clojurewerkz.quartzite.jobs :refer [defjob]]
+            [clojurewerkz.quartzite.triggers :as t]
+            [clojurewerkz.quartzite.schedule.simple :as s]
+            [clojurewerkz.quartzite.schedule.daily-interval :as di]))
+
+(defjob DeleteExpired [_]
+  (db/delete-expired-bins))
+
+(defn build-job [job]
+  (j/build
+    (j/with-identity (j/key (:job-key job)))
+    (j/of-type (:job-type job))))
+
+(defn sched-everyday-at-midnight []
+  (di/schedule
+    (di/with-interval-in-days 1)
+    (di/every-day)
+    (di/starting-daily-at
+      (di/time-of-day 00 00 00))))
+
+(defn sched-once-every-200-ms []
+  (s/schedule
+    (s/with-interval-in-milliseconds 200)))
+
+(defn configure-trigger [trigger]
+  (t/build
+    (t/with-identity (t/key (:trigger-key trigger)))
+    (t/start-now)
+    (t/with-schedule ((:schedule trigger)))))
+
+(defn schedule [job trigger]
+  (let [scheduler (-> (qs/initialize) qs/start)]
+    (qs/schedule scheduler job trigger)
+    scheduler))

--- a/src/httpeek/main.clj
+++ b/src/httpeek/main.clj
@@ -1,0 +1,10 @@
+(ns httpeek.main
+  (:require [httpeek.jobs :as jobs]
+            [httpeek.handler :refer [app*]])
+(:import [httpeek.jobs DeleteExpired]))
+
+(defn -main [_]
+  (let [trigger (jobs/configure-trigger {:trigger-key "trigger.ms"
+                                         :schedule jobs/sched-once-every-200-ms})
+        job (jobs/build-job {:job-type DeleteExpired :job-key "test"})]
+    (jobs/schedule job trigger)))

--- a/src/httpeek/views.clj
+++ b/src/httpeek/views.clj
@@ -54,6 +54,11 @@
         [:textarea#bin-response-body.mdl-textfield__input {:type "text" :name "body"}]
         [:label.mdl-textfield__label {:for "bin-response-body"} (h/h "Body")]]]]
      [:div.mdl-grid.mdl-grid--nesting
+      [:div.mdl-cell.mdl-cell--4-col
+       [:div#bin-response-body.mdl-textfield.mdl-js-textfield
+        [:input#expiration.mdl-textfield__input {:type "text" :name "expiration"}]
+        [:label.mdl-textfield__label {:for "expiration"} (h/h "Hours Until Expiration")]]]]
+     [:div.mdl-grid.mdl-grid--nesting
       [:div.mdl-cell.mdl-cell--6-col
        [:button.mdl-button.mdl-js-button.mdl-button--primary {:type "submit"} (h/h "Create Bin")
         [:i.material-icons (h/h "add")]]


### PR DESCRIPTION
Addresses the following story:

As a user
  Before I create a bin I can type in the expiration time field to set 
  the number hours from now when a bin will expire. 

  When I do not fill in the expiration time field
  Then the default time of 24 hours is used

  When I type a number less than 1 or greater than 24
  Then I am given a warning 

  When I try to access an expired bin.
  Then I am given a not found page
